### PR TITLE
Sa 520/fix new workplace saving to db - wrong notification

### DIFF
--- a/client/src/api/workplace.js
+++ b/client/src/api/workplace.js
@@ -32,7 +32,7 @@ const fetchInternalWorkplaceById = async id => {
 // Post a workplace to internal saukko database.
 const postWorkplace = async workplace => {
   const response = await axios.post(`/api/workplace`, workplace)
-  return response.data
+  return response
 }
 
 // Update a workplace in internal saukko database.


### PR DESCRIPTION
Replace response.data with the full response object to get the status property when saving a new workplace to the db (to get the success Notification message).