### PR TITLE
clear cookies when jwt expires

### DIFF
--- a/server/src/middlewares/middleware.tokens.ts
+++ b/server/src/middlewares/middleware.tokens.ts
@@ -48,6 +48,14 @@ const tokensMiddleware = async (req: Request, res: Response, next: NextFunction)
       .clearCookie("token", { httpOnly: true })
       .send();
     }
+
+    if ((error as any)?.name === "TokenExpiredError") {
+      return res.status(401)
+        .clearCookie("auth_state")
+        .clearCookie("token", { httpOnly: true })
+        .send();
+    }
+    
     res.status(500).json({ errorMessage: "Internal" })
   }
 }


### PR DESCRIPTION
Fixes the issue of cookies not clearing after expiring. User no longer has to clear cookies manually.