### PR TITLE
Sa 638 fix application crash on lis tutkinto page

### DIFF
--- a/client/src/components/Stepper/Stepper.jsx
+++ b/client/src/components/Stepper/Stepper.jsx
@@ -69,8 +69,9 @@ const Stepper = ({ activePage, totalPages, data }) => {
           {data.map((step, index) => (
             <span
               key={index}
-              className={`page-text ${activePage >= index + 1 ? 'active' : ''}`}
-              onClick={() => navigate(step.url)}
+              className={`page-text ${activePage === index + 1 ? 'active' : ''}`}
+              // Navigating using this makes no sense
+              //onClick={() => navigate(step.url)}
             >
               {step.label}
             </span>

--- a/client/src/components/Stepper/Stepper.jsx
+++ b/client/src/components/Stepper/Stepper.jsx
@@ -21,13 +21,10 @@
   />
 */
 
-import { useNavigate } from 'react-router-dom';
 import { Icon } from '@iconify/react';
 import PropTypes from 'prop-types';
 
 const Stepper = ({ activePage, totalPages, data }) => {
-  const navigate = useNavigate();
-
   const createSteppers = () => {
     const steppers = [];
 
@@ -70,8 +67,6 @@ const Stepper = ({ activePage, totalPages, data }) => {
             <span
               key={index}
               className={`page-text ${activePage === index + 1 ? 'active' : ''}`}
-              // Navigating using this makes no sense
-              //onClick={() => navigate(step.url)}
             >
               {step.label}
             </span>

--- a/client/src/components/Stepper/_stepper.scss
+++ b/client/src/components/Stepper/_stepper.scss
@@ -67,7 +67,8 @@
 
       &.active {
         color: var(--link-blue);
-        text-decoration: underline;
+        font-weight: bold;
+        //text-decoration: underline;
       }
     }
   }

--- a/client/src/pages/AdminDegree/DegreeUnits/DegreeUnits.jsx
+++ b/client/src/pages/AdminDegree/DegreeUnits/DegreeUnits.jsx
@@ -15,7 +15,10 @@ import useStore from '../../../store/zustand/formStore';
 import { useHeadingContext } from '../../../store/context/headingContectProvider';
 import WithDegree from '../../../HOC/withDegree';
 
+import useUnitsStore from '../../../store/zustand/unitsStore';
+
 function DegreeUnits({ degree }) {
+  const checkedUnits = useUnitsStore((state) => state.checkedUnits);
   const navigate = useNavigate();
   const params = useParams();
 
@@ -98,7 +101,7 @@ function DegreeUnits({ degree }) {
         <PageNavigationButtons
           handleBack={() => navigate(`/degrees/${params.degreeId}`)}
           handleForward={() => navigate(`/degrees/${params.degreeId}/edit-units`)}
-          showForwardButton={true}
+          showForwardButton={checkedUnits.length > 0}
         />
       </section>
     </div>

--- a/client/src/pages/AdminDegree/SpecifyTasks/SpecifyTasks.jsx
+++ b/client/src/pages/AdminDegree/SpecifyTasks/SpecifyTasks.jsx
@@ -32,7 +32,7 @@ function SpecifyTasks({ degree }) {
 
   // Initialize state
   const [assessments, setAssessments] = useState([]);
-  const [activeStep, setActiveStep] = useState(0);
+  const [activeStep, setActiveStep] = useState(0); // Index of the selected unit
   const [savedDataCriteria, setSavedDataCriteria] = useState([]);
   const { degreeName } = useStore();
   const checkedUnits = useUnitsStore((state) => state.checkedUnits);
@@ -53,7 +53,7 @@ function SpecifyTasks({ degree }) {
 
   const handleSave = (title, criteria) => {
     const newData = { ...savedDataCriteria };
-    newData[checkedUnits[activeStep]._id].push({ title, criteria });
+    newData[checkedUnits[activeStep]._id].push({ title, criteria }); // Error
     setSavedDataCriteria(newData);
   };
 
@@ -148,7 +148,7 @@ function SpecifyTasks({ degree }) {
                     sx={{ 
                       fontWeight: 'bold',
                       color: '#000000',
-                      position:'static'
+                      //position:'static'
                     }}
                     size='small'
                     onClick={handleNext}
@@ -169,7 +169,7 @@ function SpecifyTasks({ degree }) {
                       fontWeight: 'bold', 
                       color: '#000000',
                       //position: 'static'
-                     }}
+                    }}
                     size='small'
                     onClick={handleBack}
                     disabled={activeStep === 0}
@@ -198,10 +198,15 @@ function SpecifyTasks({ degree }) {
                 criteria='Kriteerit'
                 hideCancelButton={true}
                 onSave={(title, criteria) => {
+                  // Check if user actually has checked units
+                  if (!checkedUnits[activeStep]) {
+                    return;
+                  }
+
                   setAssessments((prevAssessments) => [
                     ...prevAssessments,
                     {
-                      unitId: checkedUnits[activeStep]._id,
+                      unitId: checkedUnits[activeStep]._id, // error
                       name: title,
                       criteria: criteria,
                     },
@@ -235,7 +240,7 @@ function SpecifyTasks({ degree }) {
                 sx={{ 
                   paddingLeft: 0, 
                   textTransform: 'none',
-                 }}
+                }}
               >
                 + Lisää ammattitaitovaatimukset
               </Button>


### PR DESCRIPTION
Prevents the website from crashing in the "lisää ammattitaitovaatimukset" menu.

The site crashed if the user tried to add requirements to a unit when they had no selected any units. Now user must select a unit to proceed in the forms.

I've also disabled navigation in the Stepper component. It allowed the user to skip sections of the forms which made no sense. The Stepper component also did not display the state of the form logically if the user happened to backtrack.